### PR TITLE
Last touches (readability and consistency)

### DIFF
--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -382,7 +382,7 @@ func expectCTsForMetricVecValues(t testing.TB, vec *MetricVec, typ dto.MetricTyp
 		}
 
 		if !gotTs.Equal(ct) {
-			t.Errorf("expected created timestamp for counter with label value %q: %s, got %s", val, ct, gotTs)
+			t.Errorf("expected created timestamp for %s with label value %q: %s, got %s", typ, val, ct, gotTs)
 		}
 	}
 }

--- a/prometheus/example_metricvec_test.go
+++ b/prometheus/example_metricvec_test.go
@@ -14,6 +14,8 @@
 package prometheus_test
 
 import (
+	"fmt"
+
 	"google.golang.org/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
@@ -124,7 +126,7 @@ func ExampleMetricVec() {
 	if err != nil || len(metricFamilies) != 1 {
 		panic("unexpected behavior of custom test registry")
 	}
-	printlnNormalized(metricFamilies[0])
+	fmt.Println(toNormalizedJSON(metricFamilies[0]))
 
 	// Output:
 	// {"name":"library_version_info","help":"Versions of the libraries used in this binary.","type":"GAUGE","metric":[{"label":[{"name":"library","value":"k8s.io/client-go"},{"name":"version","value":"0.18.8"}],"gauge":{"value":1}},{"label":[{"name":"library","value":"prometheus/client_golang"},{"name":"version","value":"1.7.1"}],"gauge":{"value":1}}]}

--- a/prometheus/expvar_collector_test.go
+++ b/prometheus/expvar_collector_test.go
@@ -81,7 +81,7 @@ func ExampleNewExpvarCollector() {
 		if !strings.Contains(m.Desc().String(), "expvar_memstats") {
 			metric.Reset()
 			m.Write(&metric)
-			metricStrings = append(metricStrings, protoToNormalizedJSON(&metric))
+			metricStrings = append(metricStrings, toNormalizedJSON(&metric))
 		}
 	}
 	sort.Strings(metricStrings)

--- a/prometheus/histogram_test.go
+++ b/prometheus/histogram_test.go
@@ -416,8 +416,8 @@ func TestHistogramExemplar(t *testing.T) {
 		Name:    "test",
 		Help:    "test help",
 		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
 	}).(*histogram)
-	histogram.now = func() time.Time { return now }
 
 	ts := timestamppb.New(now)
 	if err := ts.CheckValid(); err != nil {
@@ -470,7 +470,7 @@ func TestHistogramExemplar(t *testing.T) {
 
 func TestNativeHistogram(t *testing.T) {
 	now := time.Now()
-	nowFn := func() time.Time { return now }
+
 	scenarios := []struct {
 		name             string
 		observations     []float64 // With simulated interval of 1m.
@@ -501,7 +501,7 @@ func TestNativeHistogram(t *testing.T) {
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(5)},
 					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(10)},
 				},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -513,7 +513,7 @@ func TestNativeHistogram(t *testing.T) {
 				Schema:           proto.Int32(3),
 				ZeroThreshold:    proto.Float64(2.938735877055719e-39),
 				ZeroCount:        proto.Uint64(0),
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -529,7 +529,7 @@ func TestNativeHistogram(t *testing.T) {
 				PositiveSpan: []*dto.BucketSpan{
 					{Offset: proto.Int32(0), Length: proto.Uint32(0)},
 				},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -548,7 +548,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{1, 0, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -565,7 +565,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(-2), Length: proto.Uint32(6)},
 				},
 				PositiveDelta:    []int64{2, 0, 0, 2, -1, -2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -611,7 +611,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(-1), Length: proto.Uint32(4)},
 				},
 				PositiveDelta:    []int64{2, 2, 3, -6},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -628,7 +628,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -649,7 +649,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -671,7 +671,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -688,7 +688,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -706,7 +706,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(4092), Length: proto.Uint32(1)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2, -1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -727,7 +727,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -745,7 +745,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -763,7 +763,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				PositiveDelta:    []int64{1, 2, -1, -2, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -782,7 +782,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
 				PositiveDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -801,7 +801,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
 				PositiveDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -821,7 +821,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(8 * time.Minute)), // We expect reset to happen after 8 observations.
 			},
 		},
 		{
@@ -839,7 +839,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, -1, 2, -2, 2},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -857,7 +857,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(0), Length: proto.Uint32(5)},
 				},
 				NegativeDelta:    []int64{1, 2, -1, -2, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -876,7 +876,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(1), Length: proto.Uint32(7)},
 				},
 				NegativeDelta:    []int64{1, 1, -2, 2, -2, 0, 1},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -895,7 +895,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(2), Length: proto.Uint32(7)},
 				},
 				NegativeDelta:    []int64{2, -2, 2, -2, 0, 1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now),
 			},
 		},
 		{
@@ -915,7 +915,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				NegativeDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(8 * time.Minute)), // We expect reset to happen after 8 observations.
 			},
 		},
 		{
@@ -934,7 +934,7 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(10 * time.Minute)), // We expect reset to happen after 9 minutes.
 			},
 		},
 		{
@@ -954,13 +954,15 @@ func TestNativeHistogram(t *testing.T) {
 					{Offset: proto.Int32(7), Length: proto.Uint32(2)},
 				},
 				PositiveDelta:    []int64{1, 0},
-				CreatedTimestamp: timestamppb.New(nowFn()),
+				CreatedTimestamp: timestamppb.New(now.Add(10 * time.Minute)), // We expect reset to happen after 9 minutes.
 			},
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
+			ts := now
+
 			his := NewHistogram(HistogramOpts{
 				Name:                            "name",
 				Help:                            "help",
@@ -969,13 +971,10 @@ func TestNativeHistogram(t *testing.T) {
 				NativeHistogramMaxBucketNumber:  s.maxBuckets,
 				NativeHistogramMinResetDuration: s.minResetDuration,
 				NativeHistogramMaxZeroThreshold: s.maxZeroThreshold,
-				now:                             nowFn,
+				now:                             func() time.Time { return ts },
 			})
-			ts := time.Now().Add(30 * time.Second)
-			now := func() time.Time {
-				return ts
-			}
-			his.(*histogram).now = now
+
+			ts = ts.Add(time.Minute)
 			for _, o := range s.observations {
 				his.Observe(o)
 				ts = ts.Add(time.Minute)
@@ -1000,6 +999,8 @@ func TestNativeHistogramConcurrency(t *testing.T) {
 	rand.Seed(42)
 
 	it := func(n uint32) bool {
+		ts := time.Now().Add(30 * time.Second).Unix()
+
 		mutations := int(n%1e4 + 1e4)
 		concLevel := int(n%5 + 1)
 		total := mutations * concLevel
@@ -1016,13 +1017,10 @@ func TestNativeHistogramConcurrency(t *testing.T) {
 			NativeHistogramMaxBucketNumber:  50,
 			NativeHistogramMinResetDuration: time.Hour, // Comment out to test for totals below.
 			NativeHistogramMaxZeroThreshold: 0.001,
+			now: func() time.Time {
+				return time.Unix(atomic.LoadInt64(&ts), 0)
+			},
 		})
-
-		ts := time.Now().Add(30 * time.Second).Unix()
-		now := func() time.Time {
-			return time.Unix(atomic.LoadInt64(&ts), 0)
-		}
-		his.(*histogram).now = now
 
 		allVars := make([]float64, total)
 		var sampleSum float64
@@ -1220,4 +1218,42 @@ func TestHistogramVecCreatedTimestamp(t *testing.T) {
 	if metric.Histogram.CreatedTimestamp.AsTime().Unix() != now.Unix() {
 		t.Errorf("expected created timestamp %d, got %d", now.Unix(), metric.Histogram.CreatedTimestamp.AsTime().Unix())
 	}
+}
+
+func TestHistogramVecCreatedTimestampWithDeletes(t *testing.T) {
+	now := time.Now()
+
+	histogramVec := NewHistogramVec(HistogramOpts{
+		Name:    "test",
+		Help:    "test help",
+		Buckets: []float64{1, 2, 3, 4},
+		now:     func() time.Time { return now },
+	}, []string{"label"})
+
+	// First use of "With" should populate CT.
+	histogramVec.WithLabelValues("1")
+	expected := map[string]time.Time{"1": now}
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
+
+	// Two more labels at different times.
+	histogramVec.WithLabelValues("2")
+	expected["2"] = now
+
+	now = now.Add(1 * time.Hour)
+
+	histogramVec.WithLabelValues("3")
+	expected["3"] = now
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
+
+	// Recreate metric instance should reset created timestamp to now.
+	histogramVec.DeleteLabelValues("1")
+	histogramVec.WithLabelValues("1")
+	expected["1"] = now
+
+	now = now.Add(1 * time.Hour)
+	expectCTsForMetricVecValues(t, histogramVec.MetricVec, dto.MetricType_HISTOGRAM, expected)
 }

--- a/prometheus/metric.go
+++ b/prometheus/metric.go
@@ -93,7 +93,8 @@ type Opts struct {
 	// https://prometheus.io/docs/instrumenting/writing_exporters/#target-labels-not-static-scraped-labels
 	ConstLabels Labels
 
-	now func() time.Time // For testing, all constructors put time.Now() here.
+	// now is for testing purposes, by default it's time.Now.
+	now func() time.Time
 }
 
 // BuildFQName joins the given three name components by "_". Empty name

--- a/prometheus/summary.go
+++ b/prometheus/summary.go
@@ -147,7 +147,8 @@ type SummaryOpts struct {
 	// "github.com/bmizerany/perks/quantile").
 	BufCap uint32
 
-	now func() time.Time // For testing, all constructors put time.Now() here.
+	// now is for testing purposes, by default it's time.Now.
+	now func() time.Time
 }
 
 // SummaryVecOpts bundles the options to create a SummaryVec metric.
@@ -252,7 +253,7 @@ func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
 		coldBuf:        make([]float64, 0, opts.BufCap),
 		streamDuration: opts.MaxAge / time.Duration(opts.AgeBuckets),
 	}
-	s.headStreamExpTime = time.Now().Add(s.streamDuration)
+	s.headStreamExpTime = opts.now().Add(s.streamDuration)
 	s.hotBufExpTime = s.headStreamExpTime
 
 	for i := uint32(0); i < opts.AgeBuckets; i++ {

--- a/prometheus/value.go
+++ b/prometheus/value.go
@@ -144,11 +144,11 @@ func NewConstMetricWithCreatedTimestamp(desc *Desc, valueType ValueType, value f
 	case CounterValue:
 		break
 	default:
-		return nil, errors.New("Created timestamps are only supported for counters")
+		return nil, errors.New("created timestamps are only supported for counters")
 	}
 
 	metric := &dto.Metric{}
-	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, &ct); err != nil {
+	if err := populateMetric(valueType, value, MakeLabelPairs(desc, labelValues), nil, metric, timestamppb.New(ct)); err != nil {
 		return nil, err
 	}
 
@@ -191,15 +191,11 @@ func populateMetric(
 	labelPairs []*dto.LabelPair,
 	e *dto.Exemplar,
 	m *dto.Metric,
-	createdTimestamp *time.Time,
+	ct *timestamppb.Timestamp,
 ) error {
 	m.Label = labelPairs
 	switch t {
 	case CounterValue:
-		var ct *timestamppb.Timestamp
-		if createdTimestamp != nil {
-			ct = timestamppb.New(*createdTimestamp)
-		}
 		m.Counter = &dto.Counter{Value: proto.Float64(v), Exemplar: e, CreatedTimestamp: ct}
 	case GaugeValue:
 		m.Gauge = &dto.Gauge{Value: proto.Float64(v)}

--- a/prometheus/value_test.go
+++ b/prometheus/value_test.go
@@ -61,7 +61,8 @@ func TestNewConstMetricInvalidLabelValues(t *testing.T) {
 
 func TestNewConstMetricWithCreatedTimestamp(t *testing.T) {
 	now := time.Now()
-	testCases := []struct {
+
+	for _, tcase := range []struct {
 		desc             string
 		metricType       ValueType
 		createdTimestamp time.Time
@@ -82,30 +83,27 @@ func TestNewConstMetricWithCreatedTimestamp(t *testing.T) {
 			expecErr:         false,
 			expectedCt:       timestamppb.New(now),
 		},
-	}
-
-	for _, test := range testCases {
-		test := test
-		t.Run(test.desc, func(t *testing.T) {
+	} {
+		t.Run(tcase.desc, func(t *testing.T) {
 			metricDesc := NewDesc(
 				"sample_value",
 				"sample value",
 				nil,
 				nil,
 			)
-			m, err := NewConstMetricWithCreatedTimestamp(metricDesc, test.metricType, float64(1), test.createdTimestamp)
-			if test.expecErr && err == nil {
-				t.Errorf("Expected error is test %s, got no err", test.desc)
+			m, err := NewConstMetricWithCreatedTimestamp(metricDesc, tcase.metricType, float64(1), tcase.createdTimestamp)
+			if tcase.expecErr && err == nil {
+				t.Errorf("Expected error is test %s, got no err", tcase.desc)
 			}
-			if !test.expecErr && err != nil {
-				t.Errorf("Didn't expect error in test %s, got %s", test.desc, err.Error())
+			if !tcase.expecErr && err != nil {
+				t.Errorf("Didn't expect error in test %s, got %s", tcase.desc, err.Error())
 			}
 
-			if test.expectedCt != nil {
+			if tcase.expectedCt != nil {
 				var metric dto.Metric
 				m.Write(&metric)
-				if metric.Counter.CreatedTimestamp.AsTime() != test.expectedCt.AsTime() {
-					t.Errorf("Expected timestamp %v, got %v", test.expectedCt, &metric.Counter.CreatedTimestamp)
+				if metric.Counter.CreatedTimestamp.AsTime() != tcase.expectedCt.AsTime() {
+					t.Errorf("Expected timestamp %v, got %v", tcase.expectedCt, &metric.Counter.CreatedTimestamp)
 				}
 			}
 		})


### PR DESCRIPTION
Changes:

* Comments for "now" are more explicit and not inlined.
* populateMetrics is simpler and bit more efficient without timestamp to time to timestamp conversionts for more common code.
* Test consistency and simplicity - the fewer variables the better.
* Fixed inconsistency for v2 and MetricVec - let's pass opt.now consistently.
* We don't need TestCounterXXXTimestamp - we test CT in many other places already.
* Added more involved test for counter vectors with created timestamp.
* Refactored normalization for simplicity.
* Make histogram, summaries now consistent.
* Simplified histograms CT flow and implemented proper CT on reset.

TODO for next PRs:
* NewConstSummary and NewConstHistogram - ability to specify CTs there.